### PR TITLE
Update how-to-run

### DIFF
--- a/how-to-run.md
+++ b/how-to-run.md
@@ -3,49 +3,221 @@ layout: page
 permalink: /how-to-run/
 ---
 
-- [How to Run](#how-to-run)
-  * [With the optional launcher](#with-the-optional-launcher)
-  * [Without the optional launcher](#without-the-optional-launcher)
+- [Install](#install)
+- [Configuration](#configuration)
+
+## Install
+
+All the options below require the **original Jagged Alliance 2 game** on your device. Make sure you do a full, clean install. If you have a game with the 1.13 mod installed, it will not work.
+
+The original game can be obtained through
+
+- GOG: [Jagged Alliance 2](https://www.gog.com/en/game/jagged_alliance_2)
+- Steam: [Jagged Alliance 2 Gold](https://store.steampowered.com/app/1620/Jagged_Alliance_2_Gold/)
+- Steam: [Jagged Alliance 2 Wildfire](https://store.steampowered.com/app/215930/Jagged_Alliance_2__Wildfire/)
+  - The original game files will be in the `JA2Classic` subdirectory, not in the `Game` subdirectory
+  - JA2 Stracciatella currently does not support Wildfire itself, only the [Wildfire maps through a mod](https://github.com/ja2-stracciatella/mod-wildfire-maps)
+- Buying CDs (if you can find someone who wants to sell)
+
+Follow the instructions for your platform to install JA2 Stracciatella:
+
+<div id="accordion">
+  <div class="card">
+    <div class="card-header" id="heading-windows-installer">
+      <a data-toggle="collapse" data-target="#collapse-windows-installer" aria-expanded="false" aria-controls="collapse-windows-installer" href="javascript:">
+         Windows installer
+      </a>
+    </div>
+    <div id="collapse-windows-installer" class="collapse" aria-labelledby="heading-windows-installer" data-parent="#accordion">
+      <div class="card-body">
+        <ol>
+           <li>
+               <p><a href="/download" target="_blank">Download the installer</a> and install Stracciatella wherever you want. Make sure to uninstall any previous version first if you want to avoid conflicts.</p>
+           </li>
+           <li>
+               <p>Run Stracciatella from the start menu. This should bring up the launcher.</p>
+           </li>
+           <li>
+               <p>Change <code>JA2 Game Directory</code> to the directory where your original game files are located.</p>
+           </li>
+           <li>
+               <p>Select the game version of your original game files, or click the "Guess Game Version" button to have the launcher auto-detect it for you.</p>
+           </li>
+           <li>
+               <p>Adapt other settings to your liking in the <code>Data</code>, <code>Mods</code> and <code>Settings</code> tab.</p>
+           </li>
+           <li>
+               <p>Start the game in the <code>Play</code> tab.</p>
+           </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-header" id="heading-windows-zip">
+      <a data-toggle="collapse" data-target="#collapse-windows-zip" aria-expanded="false" aria-controls="collapse-windows-zip" href="javascript:">
+         Windows ZIP
+      </a>
+    </div>
+    <div id="collapse-windows-zip" class="collapse" aria-labelledby="heading-windows-zip" data-parent="#accordion">
+      <div class="card-body">
+        <ol>
+           <li>
+               <p><a href="/download" target="_blank">Download the ZIP</a> and extract it wherever you want. Do not extract it in the original game directory.</p>
+           </li>
+           <li>
+               <p>Navigate to the Stracciatella directory and run <code>ja2-launcher.exe</code>. This should bring up the launcher.</p>
+           </li>
+           <li>
+               <p>Change <code>JA2 Game Directory</code> to the directory where your original game files are located.</p>
+           </li>
+           <li>
+               <p>Select the game version of your original game files, or click the "Guess Game Version" button to have the launcher auto-detect it for you.</p>
+           </li>
+           <li>
+               <p>Adapt other settings to your liking in the <code>Data</code>, <code>Mods</code> and <code>Settings</code> tab.</p>
+           </li>
+           <li>
+               <p>Start the game in the <code>Play</code> tab.</p>
+           </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-header" id="heading-linux">
+         <a data-toggle="collapse" data-target="#collapse-linux" aria-expanded="false" aria-controls="collapse-linux" href="javascript:">
+            Linux
+        </a>
+    </div>
+    <div id="collapse-linux" class="collapse" aria-labelledby="heading-linux" data-parent="#accordion">
+      <div class="card-body">
+        <ol>
+           <li>
+               <p><a href="/download" target="_blank">Download the AppImage</a> and put it whereever you want.</p>
+           </li>
+           <li>
+               <p>Make the AppImage executable, either using your file manager or <code>chmod +x</code>.</p>
+           </li>
+           <li>
+               <p>Execute the AppImage. This should bring up the Stracciatella launcher.</p>
+           </li>
+           <li>
+               <p>Change <code>JA2 Game Directory</code> to the directory where your original game files are located.</p>
+           </li>
+           <li>
+               <p>Select the game version of your original game files, or click the "Guess Game Version" button to have the launcher auto-detect it for you.</p>
+           </li>
+           <li>
+               <p>Adapt other settings to your liking in the <code>Data</code>, <code>Mods</code> and <code>Settings</code> tab.</p>
+           </li>
+           <li>
+               <p>Start the game in the <code>Play</code> tab.</p>
+           </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-header" id="heading-macos">
+         <a data-toggle="collapse" data-target="#collapse-macos" aria-expanded="false" aria-controls="collapse-macos" href="javascript:">
+            macOS
+        </a>
+    </div>
+    <div id="collapse-macos" class="collapse" aria-labelledby="heading-macos" data-parent="#accordion">
+      <div class="card-body">
+        <ol>
+           <li>
+               <p><a href="/download" target="_blank">Download the macOS dmg</a> and open it.</p>
+           </li>
+           <li>
+               <p>Drag the Stracciatella app into the <code>Applications</code> folder.</p>
+           </li>
+           <li>
+               <p>Control-click the app icon in the <code>Applications</code> folder, then choose <code>Open</code> from the shortcut menu. This only needs to be done once and should bring up the Stracciatella launcher.</p>
+           </li>
+           <li>
+               <p>Change <code>JA2 Game Directory</code> to the directory where your original game files are located.</p>
+           </li>
+           <li>
+               <p>Select the game version of your original game files, or click the "Guess Game Version" button to have the launcher auto-detect it for you.</p>
+           </li>
+           <li>
+               <p>Adapt other settings to your liking in the <code>Data</code>, <code>Mods</code> and <code>Settings</code> tab.</p>
+           </li>
+           <li>
+               <p>Start the game in the <code>Play</code> tab.</p>
+           </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-header" id="heading-android">
+         <a data-toggle="collapse" data-target="#collapse-android" aria-expanded="false" aria-controls="collapse-android" href="javascript:">
+            Android
+        </a>
+    </div>
+    <div id="collapse-android" class="collapse" aria-labelledby="heading-android" data-parent="#accordion">
+      <div class="card-body">
+        <p>
+          <span class="fa fa-lg fa-info"></span>&nbsp;&nbsp;The Android app is currently not available through any store. You need to install the APK manually. Please inform yourself about allowing app installations from unknown sources for your device.
+        </p>
+        <ol>
+           <li>
+               <p>Copy the original game files to your Android device. This can be done by copying it to your device using USB or a cloud storage provider.</p>
+           </li>
+           <li>
+               <p><a href="/download" target="_blank">Download the Android APK</a> and install it.</p>
+           </li>
+           <li>
+               <p>Open the app. This should bring up the Stracciatella launcher.</p>
+           </li>
+           <li>
+               <p>Change <code>JA2 Game Directory</code> to the directory where your original game files are located.</p>
+           </li>
+           <li>
+               <p>Select the game version of your original game files. Usually this is just the language your original game is in.</p>
+           </li>
+           <li>
+               <p>Although optional, it is recommended to set the save game directory to a directory that is accessible for other apps as well. Otherwise your save games will be deleted when you uninstall the app.</p>
+           </li>
+           <li>
+               <p>Start the game with the button in the bottom right corner.</p>
+           </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+<p></p>
+
+## Configuration
+
+### Configuration File
+
+The configuration file will be created on the first start of the application. It is located in
+
+- `%USERPROFILE%\Documents\JA2\ja2.json` on Windows.
+- `~/.ja2/ja2.json` on Linux, BSD or macOS.
+- `/data/data/io.github.ja2stracciatella/ja2.json` on Android, in the apps data directory. Usually not accessible by other apps.
+
+### Savegame directory
+
+The savegame directory can be changed, for example to synchronize savegames with the cloud. By default the save games are located in
+
+- `%USERPROFILE%\Documents\JA2\SavedGames` on Windows.
+- `~/.ja2/SavedGames` on Linux, BSD or macOS.
+- `/data/data/io.github.ja2stracciatella/SavedGames` on Android, in the apps data directory. Usually not accessible by other apps.
+
+### Resolution and Scaling Mode
+
+The internal resolution lets you define how large **the tactical screen** is rendered. All other game screens are still rendered in the original `640x480` resolution and centered on the screen.
+
+In order to increase the size of the game window, you can either resize it with the window controls, or enable fullscreen.
+
+Scaling mode will determine how the internal resolution is scaled to your window.
 
 
-# How to Run
 
-1. Install the **original Jagged Alliance 2 game** on your computer. Make sure you do a full install. If you have a game with the 1.13 mod installed, it will not work.
-
-2. [Download JA2-Stracciatella](/download) or [compile](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/master/COMPILATION.md) it from the source codes. Install it wherever you want.
-
-##  With the optional launcher
-
-3. Start the launcher and use it to configure the game. It will automatically create the configuration file.
-
-4. Set “JA2 Data Directory” (“JA *Game* Directory” in nightly builds) to point to the directory where the original game was installed during step 1. You can manually enter the directory or use the “...” button to browse your computer. You have to select the directory that **contains** the directory called “Data”. Do not select the “Data” directory.
-
-5. If you haven't installed the English version of the original game, you have to select the correct “Game Version” i.e. localization. Note that the game supports two different Russian localizations: RUSSIAN for the “BUKA Agonia Vlasty” release and RUSSIAN_GOLD for the “Gold” release.
-
-## Without the optional launcher
-
-3. Start the game the first time.  It will create the configuration file in
-
-   - `%USERPROFILE%\Documents\JA2\ja2.json` on Windows.
-   - `~/.ja2/ja2.json` on Linux, BSD or OS X.
-
-4. Edit the configuration file and set parameter `game_dir` to point on the directory where the original game was installed on step 1.  You have to use the path to the directory that **contains** the directory called “Data”. Do not use the path to the “Data” directory. For example:
-
-   - `D:\games\ja2\` on Windows.
-   - `/home/user/games/ja2-installed` on Linux, BSD or OS X.
-
-5. If you have a non-english version of the original game, you need to start JA2-Stracciatella with parameter telling which version of the game you are using.  For example
-
-   - `ja2.exe -resversion FRENCH` on Windows.
-   - `ja2 -resversion FRENCH` on Linux, BSD or OS X.
-
-   You should see the start screen now.
-
-   ![Ja2 Stracciatella start screen](/img/start-screen.png)
-
-Further command line options are available. To list available options run
-
-- `ja2.exe -help` on Windows.
-- `ja2 -help` on Linux, BSD or OS X.
-
-**For even more configuration options check the [modding](mods.md) page.**
+**For even more configuration options check the [modding](/mods/) page.**


### PR DESCRIPTION
Adapts the "How to run" to more accurately describe for each platform how to make the game start. Also adds some docs about configuration.

![image](https://user-images.githubusercontent.com/848854/201854368-57707f49-ecb3-4762-ba42-7f3cc142120f.png)
